### PR TITLE
Fix error on empty string

### DIFF
--- a/src/recover.js
+++ b/src/recover.js
@@ -37,7 +37,7 @@ const process_shares = (a) => {
 	// this function's parameter ys is an array of hex strings
     let c = [];
     for (let i = 0; i < a.length; i++) {
-        let x = a[i].match(/.{1,2}/g);
+        let x = a[i].match(/.{1,2}/g) || [];
         for (let j = 0; j < x.length; j++) {
             if (c[j] == undefined)
             	c[j] = [];


### PR DESCRIPTION
Now recover fails with JS error:
`TypeError: Cannot read properties of null (reading 'length')`.

Because process_shares method take array with one empty string.

Then `let x = a[i].match(/.{1,2}/g) ;` got null.
And next string `for (let j = 0; j < x.length; j++) {` if failing.
